### PR TITLE
C786 enforce ssl

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@
 envs/
 __backend__.tf
 .nullstone/active-workspace.yml
+.terraform.lock.hcl

--- a/redis.tf
+++ b/redis.tf
@@ -20,8 +20,8 @@ resource "aws_elasticache_replication_group" "this" {
   tags                       = local.tags
   auto_minor_version_upgrade = true
   at_rest_encryption_enabled = true
-  transit_encryption_enabled = true
-  auth_token                 = random_password.auth_token.result
+  transit_encryption_enabled = var.enforce_ssl
+  auth_token                 = local.auth_token
   engine                     = "redis"
   engine_version             = var.redis_version
   node_type                  = var.node_type
@@ -32,4 +32,8 @@ resource "aws_elasticache_replication_group" "this" {
   automatic_failover_enabled = false
   num_cache_clusters         = 2
   apply_immediately          = true
+}
+
+locals {
+  auth_token = var.enforce_ssl ? random_password.auth_token.result : null
 }

--- a/redis.tf
+++ b/redis.tf
@@ -35,5 +35,7 @@ resource "aws_elasticache_replication_group" "this" {
 }
 
 locals {
+  // when transit_encrypt_enabled is false, we can't provide an auth_token
+  // see the usage of this local above for context
   auth_token = var.enforce_ssl ? random_password.auth_token.result : null
 }

--- a/variables.tf
+++ b/variables.tf
@@ -9,3 +9,9 @@ variable "node_type" {
   default     = "cache.t3.small"
   description = "The node size for each redis node. See https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/CacheNodes.SupportedTypes.html."
 }
+
+variable "enforce_ssl" {
+  type        = bool
+  default     = true
+  description = "By default, traffic to this instance will be send using ssl via the rediss protocol. Toggle this option to false in order to use an unencrypted transport."
+}

--- a/variables.tf
+++ b/variables.tf
@@ -13,5 +13,5 @@ variable "node_type" {
 variable "enforce_ssl" {
   type        = bool
   default     = true
-  description = "By default, traffic to this instance will be send using ssl via the rediss protocol. Toggle this option to false in order to use an unencrypted transport."
+  description = "By default, traffic to this instance will be sent using ssl via the rediss protocol. Toggle this option off in order to use an unencrypted transport."
 }


### PR DESCRIPTION
This PR adds a new option to the elasticache module. You can now turn off in-transit ssl using the new option.