### PR TITLE
Fix auth token

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,6 +4,10 @@ on:
     tags:
       - 'v*'
 
+env:
+  NULLSTONE_ORG: nullstone
+  NULLSTONE_API_KEY: ${{ secrets.NULLSTONE_API_KEY }}
+
 jobs:
   publish:
     runs-on: ubuntu-latest
@@ -13,24 +17,17 @@ jobs:
         shell: bash
 
     steps:
-      # Checkout the repository to the GitHub Actions runner
       - name: Checkout
         uses: actions/checkout@v2
+
+      - name: Set up Nullstone
+        uses: nullstone-io/setup-nullstone-action@v0
 
       - name: Find version
         id: version
         run: echo ::set-output name=tag::${GITHUB_REF#refs/tags/v}
 
-      # Package files into tgz
-      - name: Package
-        run: tar -cvzf module.tgz *.tf README.md
-
-      # Publish to nullstone
-      - name: Publish
-        env:
-          NULLSTONE_ORG: nullstone
-          NULLSTONE_MODULE: aws-elasticache
-          RELEASE_VERSION: ${{ steps.version.outputs.tag }}
-        run: |-
-          curl -XPOST -F "file=@module.tgz" -H "X-Nullstone-Key: ${{ secrets.NULLSTONE_API_KEY }}" \
-            https://api.nullstone.io/orgs/${NULLSTONE_ORG}/modules/${NULLSTONE_MODULE}/versions?version=${RELEASE_VERSION}
+      - id: publish
+        name: Publish
+        run: |
+          nullstone modules publish --version=${{ steps.version.outputs.tag }}

--- a/auth_token.tf
+++ b/auth_token.tf
@@ -13,12 +13,12 @@ resource "aws_secretsmanager_secret" "auth_token" {
   name = "${local.resource_name}/auth_token"
   tags = local.tags
 
-  count = local.auth_token == null ? 0 : 1
+  count = local.has_auth_token ? 1 : 0
 }
 
 resource "aws_secretsmanager_secret_version" "auth_token" {
   secret_id     = aws_secretsmanager_secret.auth_token[count.index].id
   secret_string = local.auth_token
 
-  count = local.auth_token == null ? 0 : 1
+  count = local.has_auth_token ? 1 : 0
 }

--- a/redis.tf
+++ b/redis.tf
@@ -37,5 +37,6 @@ resource "aws_elasticache_replication_group" "this" {
 locals {
   // when transit_encrypt_enabled is false, we can't provide an auth_token
   // see the usage of this local above for context
-  auth_token = var.enforce_ssl ? random_password.auth_token.result : null
+  has_auth_token = var.enforce_ssl ? true : false
+  auth_token     = local.has_auth_token ? random_password.auth_token.result : null
 }


### PR DESCRIPTION
Fixed error where a plan cannot run with `var.enforce_ssl = true` because the secret resource count relies on a `random_string.password`. I changed the secret resource to rely on the variable.

Additionally, I updated the github workflow to use the nullstone github action to publish the module.